### PR TITLE
fix: 🐛 タイトル画面に戻らない現象を修正

### DIFF
--- a/glossary.html
+++ b/glossary.html
@@ -30,7 +30,7 @@ https://getbootstrap.jp/docs/5.3/components/modal/
     <div class="menubar">
         <!-- このh1タグにタイトルが自動で入るので、ここはいじらない -->
         <h1 class="menubar-text">用語一覧</h1>
-        <a class="btn btn-primary menubar-back-btn" type="button" 　onclick="location:href='selectLevel.html'" href="../index.html" style="margin-top: -72px;">＜＜戻る</a><!--なぜか表示されない？-->
+        <a class="btn btn-primary menubar-back-btn" type="button" onclick="location:href='index.html'" style="margin-top: -72px;">＜＜戻る</a><!--なぜか表示されない？-->
     </div>
 
     <div class="accordion" id="prefectureList"></div>


### PR DESCRIPTION
## 概要

タイトル画面に戻らない現象の修正，gitignoreを追加しました．

## 変更点

このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。

- 用語解説画面の戻るボタンの遷移先を修正しました
- .gitignoreファイルを追加しました